### PR TITLE
240702

### DIFF
--- a/src/baekjoon/계단_오르기_2579.java
+++ b/src/baekjoon/계단_오르기_2579.java
@@ -1,0 +1,43 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * n <= 300
+ * step[i] <= 10,000
+ * 시간 제한: 1초
+ *
+ * O(N) = 300 < 10^9
+ * O(N^3) = (10^2)^3 < 10^9
+ * 따라서 O(N^3) 시간복잡도까지는 시간초과 안 걸림 (백트래킹 300^300 혹은 2^300 => 시간초과 걸림)
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N)
+ * 메모리: 14216 KB, 시간: 124ms (0.124초)
+ **************************************************************************************/
+
+public class 계단_오르기_2579 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int[] step = new int[301];
+        int[] dp = new int[301];
+
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            step[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dp[1] = step[1];
+        dp[2] = step[1] + step[2];
+        dp[3] = Math.max(step[1], step[2]) + step[3];
+
+        for (int i = 4; i <= n; i++) {
+            dp[i] = Math.max(dp[i - 2], dp[i - 3] + step[i - 1]) + step[i];
+        }
+
+        System.out.println(dp[n]);
+    }
+}

--- a/src/baekjoon/일로_만들기_1463.java
+++ b/src/baekjoon/일로_만들기_1463.java
@@ -1,0 +1,44 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 <= n <= 10^6
+ * 시간 제한: 0.15초 (아마 자바는 좀 더 늘어난 듯)
+ *
+ * 따라서, 15,000,000 이내의 연산을 만족하는 알고리즘을 구현해야함
+ * 최악 N = 10,000,000 이므로, 알고리즘은 O(N)을 만족하는 시간복잡도를 가져야함
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N)
+ * 메모리: 20780 KB, 시간: 184 ms
+ **************************************************************************************/
+
+public class 일로_만들기_1463 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int[] dp = new int[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            dp[i] = Integer.MAX_VALUE;
+        }
+
+        dp[n] = 0;
+
+        for (int i = n; i > 1; i--) {
+            if (i % 3 == 0) {
+                dp[i / 3] = Math.min(dp[i] + 1, dp[i / 3]);
+            }
+
+            if (i % 2 == 0) {
+                dp[i / 2] = Math.min(dp[i] + 1, dp[i / 2]);
+            }
+
+            dp[i - 1] = Math.min(dp[i - 1], dp[i] + 1);
+        }
+        System.out.println(dp[1]);
+    }
+}

--- a/src/baekjoon/일이삼_더하기_9095.java
+++ b/src/baekjoon/일이삼_더하기_9095.java
@@ -1,0 +1,42 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * n <= 11
+ * 시간 제한: 1초
+ *
+ * 따라서 O(10^7) 이하의 시간복잡도를 만족하는 알고리즘 구현 필요 (하지만 10^7은 시간초과 걸릴 가능성 큼)
+ * 백트래킹으로 모든 조합을 구한 뒤, n을 만족하는지 체크하는 로직으로 푼다면 (가지치기를 하지 않는다는 전제 하에) 10^10 시간복잡도를 가져 시간초과 난다고 생각
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N)
+ * 메모리: 14216 KB, 시간: 124ms (0.124초)
+ **************************************************************************************/
+
+public class 일이삼_더하기_9095 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int t = Integer.parseInt(st.nextToken());
+
+        while (t-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());
+
+            int dp[] = new int[12]; // 최대값으로 설정해줘야함.. n = 2 입력받았을 때, 31번째 줄 dp[3] = 4 에서 런타임 오류남
+            dp[0] = 0;
+            dp[1] = 1;
+            dp[2] = 2;
+            dp[3] = 4;
+
+            for (int i = 4; i <= n; i++) {
+                dp[i] = dp[i - 1] + dp[i - 2] + dp[i - 3];
+                // dp[i]에 dp[i-1] + "1" 포함
+                // dp[i]에 dp[i-2] + "2" 포함
+                // dp[i]에 dp[i-3] + "3" 포함
+            }
+            System.out.println(dp[n]);
+        }
+    }
+}


### PR DESCRIPTION
 **dp 문제를 백트래킹으로 풀면 시간초과가 난다는 사실을 확실히 알게되었음 ^-^;** 

## 2579: 계단 오르기
> 소요시간: 40분
> 시간복잡도: O(N)
> 메모리: 14216 KB
> 시간: 124ms (0.124초)

### 간단한 풀이과정
- 연속된 3개의 계단을 모두 밟으면 안된다는 조건이 있기에, dp[i]는 아래 두 가지 경우 중 큰 값으로 할당된다. 
  1. dp[i-2] + step[i] => i-2번째 계단에서 i번째 계단 밟기 
  2. dp[i-3] + step[i-1] + step[i] => i-3번째 계단 밟고 i-1번째 계단 밟고 i번째 계단 밟기 
 - 점화식 아이디어가 안 떠올라서 .. 구글링했습니다.. ㅜ 

## 9095: 1, 2, 3 더하기 
> 소요시간: 10분
> 시간복잡도: O(N)
> 메모리: 14216 KB
> 시간: 124ms (0.124초)

### 간단한 풀이과정 
- dp[i] = dp[i-1] + dp[i-2] + dp[i-3] 점화식 만족
- 이유는, **dp[i-1] 에 '1'을 더한 식 + dp[i-2]에 '2'를 더한 식 + dp[i-3]예 '3'을 더한 식 = i를 만들 수 있는 식의 모든 경우**가 되기 때문 

## 1463: 1로 만들기
> 소요시간: 30분 
> 시간복잡도: O(N)
> 메모리: 20780 KB
> 시간: 184 ms

### 간단한 풀이과정 
- dp[i/3] = max(dp[i/3], dp[i] + 1) 점화식 만족 
- i가 3으로 나눠진다면, dp[i/3]은 dp[i]에서 연산 횟수 + 1을 하는 값과 기존 dp[i/3]에 저장되어 있는 값 중에서 최소 값을 가지게 된다. 
  - 나머지 작업도 동일
- 위 작업을 만족하기 위해서는 dp[i]이 MAX값으로 초기화되어 있어야함