### PR TITLE
240709 + HashMap 시간복잡도

### DIFF
--- a/src/baekjoon/수찾기_1920.java
+++ b/src/baekjoon/수찾기_1920.java
@@ -1,0 +1,67 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ N ≤ 100,000
+ * 1 ≤ M ≤ 100,000
+ * -2^31 <= A[i] <= 2^31
+ *
+ * 만약 A[i]에 특정 수가 포함되어 있는지 N개의 수를 조회한다면, 최대 100,000번을 조회해야함.
+ * 이때, 특정 수는 M개가 있기에 100,000 * 100,000 = 10^10 > 10^9 => 시간초과 발생
+ * MlogN => 10^5 * 5 < 10^9 => 시간초과 발생 X
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(MlogN)
+ * 메모리: 48644 KB, 시간: 708 ms
+ **************************************************************************************/
+
+public class 수찾기_1920 {
+    private static int n;
+    private static int[] A;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        A = new int[n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            A[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(A);
+
+        st = new StringTokenizer(br.readLine());
+        int m = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < m; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            sb.append(getExistState(num) + "\n");
+        }
+        System.out.println(sb);
+    }
+
+    private static int getExistState(int num) {
+        int left = 0;
+        int right = n - 1;
+        int idx = (left + right) / 2;
+
+        while (left <= right) {
+            idx = (left + right) / 2;
+
+            if (A[idx] > num) {
+                right = idx - 1;
+            } else if (A[idx] < num) {
+                left = idx + 1;
+            } else {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/baekjoon/수찾기_1920.java
+++ b/src/baekjoon/수찾기_1920.java
@@ -12,7 +12,7 @@ import java.util.*;
  * 이때, 특정 수는 M개가 있기에 100,000 * 100,000 = 10^10 > 10^9 => 시간초과 발생
  * MlogN => 10^5 * 5 < 10^9 => 시간초과 발생 X
  *------------------------------------------------------------------------------------
- * 시간복잡도: O(MlogN)
+ * 시간복잡도: O((N+M)logN)
  * 메모리: 48644 KB, 시간: 708 ms
  **************************************************************************************/
 
@@ -31,14 +31,14 @@ public class 수찾기_1920 {
         for (int i = 0; i < n; i++) {
             A[i] = Integer.parseInt(st.nextToken());
         }
-        Arrays.sort(A);
+        Arrays.sort(A); // O(NlogN)
 
         st = new StringTokenizer(br.readLine());
         int m = Integer.parseInt(st.nextToken());
 
         st = new StringTokenizer(br.readLine());
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < m; i++) {
+        for (int i = 0; i < m; i++) { // O(MlogN)
             int num = Integer.parseInt(st.nextToken());
             sb.append(getExistState(num) + "\n");
         }

--- a/src/baekjoon/숫자카드2_10816.java
+++ b/src/baekjoon/숫자카드2_10816.java
@@ -1,0 +1,45 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ N ≤ 500,000
+ *-10,000,000 <= 숫자 카드에 적힌 수 <= 10,000,000
+ * 1 ≤ M ≤ 500,000
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(숫자카드 개수 세기: NlogN + 쿼리 처리: MlogN) = O((N+M)logN)
+ * 메모리: 198688 KB, 시간: 1816 ms
+ **************************************************************************************/
+
+public class 숫자카드2_10816 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        Map<Integer, Integer> map = new TreeMap<>();
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            if (map.containsKey(num)) {
+                map.put(num, map.get(num) + 1);
+            } else {
+                map.put(num, 1);
+            }
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int m = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < m; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            if (map.containsKey(num)) sb.append(map.get(num) + " ");
+            else sb.append("0 ");
+        }
+        System.out.println(sb);
+    }
+}

--- a/src/baekjoon/숫자카드2_10816.java
+++ b/src/baekjoon/숫자카드2_10816.java
@@ -8,8 +8,8 @@ import java.util.*;
  *-10,000,000 <= 숫자 카드에 적힌 수 <= 10,000,000
  * 1 ≤ M ≤ 500,000
  *------------------------------------------------------------------------------------
- * 시간복잡도: O(숫자카드 개수 세기: NlogN + 쿼리 처리: MlogN) = O((N+M)logN)
- * 메모리: 198688 KB, 시간: 1816 ms
+ * 시간복잡도: O(n + m)
+ * 메모리: 199440 KB, 시간: 1316 ms
  **************************************************************************************/
 
 public class 숫자카드2_10816 {
@@ -18,7 +18,7 @@ public class 숫자카드2_10816 {
         StringTokenizer st = new StringTokenizer(br.readLine());
 
         int n = Integer.parseInt(st.nextToken());
-        Map<Integer, Integer> map = new TreeMap<>();
+        Map<Integer, Integer> map = new HashMap<>();
 
         st = new StringTokenizer(br.readLine());
         for (int i = 0; i < n; i++) {
@@ -35,9 +35,10 @@ public class 숫자카드2_10816 {
 
         st = new StringTokenizer(br.readLine());
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < m; i++) {
+
+        for (int i = 0; i < m; i++) { // O(m)
             int num = Integer.parseInt(st.nextToken());
-            if (map.containsKey(num)) sb.append(map.get(num) + " ");
+            if (map.containsKey(num)) sb.append(map.get(num) + " "); // O(1)
             else sb.append("0 ");
         }
         System.out.println(sb);

--- a/src/baekjoon/숫자카드2_10816.java
+++ b/src/baekjoon/숫자카드2_10816.java
@@ -13,34 +13,65 @@ import java.util.*;
  **************************************************************************************/
 
 public class 숫자카드2_10816 {
+    private static int n;
+    private static int[] card;
+
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
 
-        int n = Integer.parseInt(st.nextToken());
-        Map<Integer, Integer> map = new HashMap<>();
+        n = Integer.parseInt(st.nextToken());
+        card = new int[n];
 
         st = new StringTokenizer(br.readLine());
         for (int i = 0; i < n; i++) {
-            int num = Integer.parseInt(st.nextToken());
-            if (map.containsKey(num)) {
-                map.put(num, map.get(num) + 1);
-            } else {
-                map.put(num, 1);
-            }
+            card[i] = Integer.parseInt(st.nextToken());
         }
+
+        Arrays.sort(card); // O(NlogN)
 
         st = new StringTokenizer(br.readLine());
         int m = Integer.parseInt(st.nextToken());
 
         st = new StringTokenizer(br.readLine());
-        StringBuilder sb = new StringBuilder();
-
-        for (int i = 0; i < m; i++) { // O(m)
+        for (int i = 0; i < m; i++) { // O(MlogN)
             int num = Integer.parseInt(st.nextToken());
-            if (map.containsKey(num)) sb.append(map.get(num) + " "); // O(1)
-            else sb.append("0 ");
+            int lowerBound = getLowerBound(num);
+            int upperBound = getUpperBound(num);
+            sb.append(upperBound - lowerBound).append(" ");
         }
+
         System.out.println(sb);
+    }
+
+    private static int getLowerBound(int num) {
+        int left = 0;
+        int right = n;
+
+        while (left < right) {
+            int idx = (left + right) / 2;
+            if (num <= card[idx]) {
+                right = idx;
+            } else { // num > card[idx]
+                left = idx + 1;
+            }
+        }
+        return right;
+    }
+
+    private static int getUpperBound(int num) {
+        int left = 0;
+        int right = n;
+
+        while (left < right) {
+            int idx = (left + right) / 2;
+            if (num < card[idx]) {
+                right = idx;
+            } else { // num >= card[idx]
+                left = idx + 1;
+            }
+        }
+        return right;
     }
 }

--- a/src/baekjoon/좌표압축_18870.java
+++ b/src/baekjoon/좌표압축_18870.java
@@ -1,0 +1,50 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ N ≤ 1,000,000 = 10^6
+ * -10^9 ≤ Xi ≤ 10^9
+ * 시간 제한: 2초
+ *
+ * list.indexOf(x[i]) 는 선형탐색이므로 O(N^2)가 된다. 따라서 시간초과 발생함
+ * HashMap.containsKey()의 시간복잡도는 평균 O(1)이지만, 최악의 경우 O(n)이 된다. 하지만 이는 매우 드문 상황
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(sorted 배열 정렬 시간) = O(nlogn)
+ * 메모리: 267152 KB, 시간: 1080 ms
+ **************************************************************************************/
+
+public class 좌표압축_18870 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int[] x = new int[n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            x[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] sorted = x.clone();
+        Arrays.sort(sorted); // O(nlogn)
+
+        // 압축: 자신의 값보다 더 작은 값을 가진 좌표의 개수
+        Map<Integer, Integer> map = new HashMap<>();
+        int index = 0;
+        for (int num : sorted) {
+            if (!map.containsKey(num)) {  // map 에는 중복된 num 값이 들어가지 않게 됨 // containsKey() 시간복잡도: 평균 O(1)
+                map.put(num, index++);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            sb.append(map.get(x[i])).append(" ");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 1920: 수 찾기
> 소요시간: 20분
> 시간복잡도: O(NlogN + MlogN)
> 메모리: 48644 KB
> 시간: 708 ms
### 간단한 풀이
- 이분탐색을 사용해, 현재 idx(start와 end의 중간)가 가리키는 값이 num보다 크다면 end = idx - 1로 수정해 범위를 줄여주고, num보다 작다면 start = idx + 1로 수정해 범위를 줄여준다.
### 시간복잡도
  - O(NlogN): A 배열을 sort 메서드로 정렬하는 시간
  - O(MlogN): M개의 값에 대해서 이분탐색을 진행하는 시간 
  - 총 시간복잡도: O(NlogN + MlogN)

## 10816: 숫자 카드2
> 소요시간: 10분
> 메모리: 199440 KB
> 시간: 1316 ms
### 간단한 풀이
- getLowerBound(num)로 card 배열 속 num 값이 가장 먼저 저장된 인덱스 값을 찾음
- getUpperBound(num)로 card 배열 속 num 값이 가장 마지막으로 저장된 인덱스 값을 찾음 (마지막 인덱스에서 +1된 값이 리턴됨) 
- 처음엔 hashMap으로 풀었는데 시간 + 메모리 너무 많이 쓰여서.. 이분탐색이 더 빠른가 싶어 이분탐색 버전으로 다시 풀어봤음.. 그러나 해당 문제에서는 오히려 이분탐색이 시간이 더 많이 걸림.. -_-; ... 찾아봤더니 hashMap이 평균 O(1), 최악 O(N)이고 이분 탐색은 O(logN) ... hashMap의 최악 O(N)은 굉장히 드물다고 함.. 그래서 hashMap의 시간이 더 빠르게 수행된거라 추측됨... 그렇지만 [여기](https://www.acmicpc.net/board/view/57406)에선 반대로 얘기하는데 ... C++이라 그런가... 이 부분은 나중에 시간이 많을 때 더 찾아보겠슴니다.. ! 

### 시간복잡도
- HashMap 자료구조를 사용하여 구현했을 땐, 메모리: 199440 KB 시간: 1316 ms 
   - O(n): num 값 입력
   - O(m): m개의 num의 개수 탐색
   - 총 시간복잡도: O(n+m)
```java
private static void useHashMap() throws IOException {
        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
        StringTokenizer st = new StringTokenizer(br.readLine());

        int n = Integer.parseInt(st.nextToken());
        Map<Integer, Integer> map = new HashMap<>();

        st = new StringTokenizer(br.readLine());
        for (int i = 0; i < n; i++) {
            int num = Integer.parseInt(st.nextToken());
            if (map.containsKey(num)) {
                map.put(num, map.get(num) + 1);
            } else {
                map.put(num, 1);
            }
        }

        st = new StringTokenizer(br.readLine());
        int m = Integer.parseInt(st.nextToken());

        st = new StringTokenizer(br.readLine());
        StringBuilder sb = new StringBuilder();

        for (int i = 0; i < m; i++) { // O(m)
            int num = Integer.parseInt(st.nextToken());
            if (map.containsKey(num)) sb.append(map.get(num) + " "); // O(1)
            else sb.append("0 ");
        }
        System.out.println(sb);
    }
```  
 
- 이분탐색으로 구현했을 땐, 메모리: 123508 KB, 1352 ms 
  - O(NlogN): card 배열 정렬
  - O(MlogN): m개의 num의 시작 인덱스와 마지막 인덱스를 이분탐색으로 탐색
  - 총 시간복잡도: O(NlogN + MlogN)

## 18870: 좌표 압축
> 소요시간: 30분
> 시간복잡도: O(NlogN)
> 메모리: 267152 KB
> 시간: 1080 ms
### 간단한 풀이
- x 배열을 입력받은 뒤, sort 메서드를 사용해 정렬
- HashMap 자료구조를 사용하여, map에는 (key: 중복 허용되지 않은 x[i] 값, value: map에 저장된 값의 개수(즉, 인덱스)) 데이터를 저장
  - HashMap의 value에 map에 저장된 값의 개수를 저장하는 이유는, HashMap은 인덱스로 접근할 수 없기에 선형탐색을 해야하는데 이를 대응하기 위해 인덱스를 저장하여 x[i]가 map의 몇 번째로 저장되었는지 O(1)에 알 수 있게 하기 위함 