### PR TITLE
240715

### DIFF
--- a/src/baekjoon/로프_2217.java
+++ b/src/baekjoon/로프_2217.java
@@ -1,0 +1,57 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ N ≤ 100,000
+ * 시간 제한: 2초
+ *
+ * [1번째 접근법] => 실패
+ * 식: 최소 로프 중량(rope[0]) x n
+ * 위의 식을 사용하려고 했으나, 최소 로프가 다른 로프들의 중량에 비해 많이 작을 경우(평균을 깎아먹는 경우) 포함 안 하는게 이득
+ *
+ * 반례 => 입력값: 총 7개, 10 2 5 7 8 일 경우, (10, 8, 7)의 로프를 사용해야 가장 많은 중량을 들어올릴 수 있음
+ *
+ * [2번째 접근법] => 실패
+ * sort()를 한 다음, maxW 값이 갱신된다면 for문 바로 종료하는 로직을 추가함
+ * 그렇게 구현한 이유는 로프가 더 추가될 수록 로프가 들 수 있는 중량은 줄어들기 때문에 평균값이 줄어든다고 생각했기 때문
+ * 하지만, (10, 8)의 로프를 사용한다면 maxW: 16, (10, 8, 7)의 로프를 사용한다면 maxW: 21
+ * 따라서, 로프가 추가될 수록 평균값이 줄어든다는 전제가 틀림
+ *
+ * [3번째 접근법] => 성공
+ * 모든 경우의 수를 탐지해서, maxW를 출력하도록 구현
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(NlogN)
+ * 메모리: 29752 KB, 시간: 344 ms
+ **************************************************************************************/
+
+public class 로프_2217 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        // k개의 로프를 사용하여 중량이 w인 물체를 들어올릴 때, 각각의 로프에는 모두 고르게 w/k 만큼 중량이 걸림
+
+        int n = Integer.parseInt(st.nextToken());
+        int[] rope = new int[n];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            rope[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(rope); // O(NlogN)
+
+        int maxW = 0;
+        int count = 1;
+
+        for (int i = n - 1; i >= 0; i--) {
+            int w = count * rope[i];
+            if (w > maxW) {
+                maxW = w;
+            }
+            count++;
+        }
+        System.out.println(maxW);
+    }
+}

--- a/src/baekjoon/보물_1026.java
+++ b/src/baekjoon/보물_1026.java
@@ -1,0 +1,44 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * N ≤ 50
+ * 0 <= A, B <= 100
+ * 시간 제한: 2초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(NlogN)
+ * 메모리: 14304 KB, 시간: 128 ms
+ **************************************************************************************/
+
+public class 보물_1026 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int[] a = new int[n];
+        Integer[] b = new Integer[n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            a[i] = Integer.parseInt(st.nextToken());
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            b[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(a);
+        Arrays.sort(b, Collections.reverseOrder()); // 내림 차순 정렬을 위해, wrapper 클래스인 Integer 로 변경
+
+        int total = 0;
+        for (int i = 0; i < n; i++) {
+            total += a[i] * b[i];
+        }
+
+        System.out.println(total);
+    }
+}

--- a/src/baekjoon/트리순회_1991.java
+++ b/src/baekjoon/트리순회_1991.java
@@ -1,0 +1,82 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ N ≤ 26
+ * 시간 제한: 2초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N)
+ * 메모리: 14296 KB, 시간: 108 ms
+ **************************************************************************************/
+
+public class 트리순회_1991 {
+    private static Map<Character, Node> nodes;
+
+    private static class Node {
+        char right, left;
+
+        Node(char left, char right) {
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        nodes = new HashMap<>();
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            char num = st.nextToken().charAt(0);
+            char left = st.nextToken().charAt(0);
+            char right = st.nextToken().charAt(0);
+
+            nodes.put(num, new Node(left, right));
+        }
+
+        prevOrder('A');
+        System.out.println();
+        inOrder('A');
+        System.out.println();
+        postOrder('A');
+        System.out.println();
+    }
+
+    private static void prevOrder(char num) {
+        if (num == '.') return;
+
+        if (nodes.containsKey(num)) {
+            Node next = nodes.get(num);
+            System.out.print(num);
+            prevOrder(next.left);
+            prevOrder(next.right);
+        }
+    }
+
+    private static void inOrder(char num) {
+        if (num == '.') return;
+
+        if (nodes.containsKey(num)) {
+            Node next = nodes.get(num);
+            inOrder(next.left);
+            System.out.print(num);
+            inOrder(next.right);
+        }
+    }
+
+    private static void postOrder(char num) {
+        if (num == '.') return;
+
+        if (nodes.containsKey(num)) {
+            Node next = nodes.get(num);
+            postOrder(next.left);
+            postOrder(next.right);
+            System.out.print(num);
+        }
+    }
+}

--- a/src/baekjoon/트리의_부모찾기_11725.java
+++ b/src/baekjoon/트리의_부모찾기_11725.java
@@ -1,0 +1,62 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 2 ≤ N ≤ 100,000
+ * 시간 제한: 1초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N)
+ * 메모리: 76820 KB, 시간: 1136 ms
+ **************************************************************************************/
+
+public class 트리의_부모찾기_11725 {
+    private static List<Integer>[] relation;
+    private static int[] parent;
+    private static boolean[] visit;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+
+        // 트리의 루트: 1
+        relation = new ArrayList[n + 1];
+
+        for (int i = 0; i <= n; i++) {
+            relation[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            relation[a].add(b);
+            relation[b].add(a);
+        }
+
+        visit = new boolean[n + 1];
+        parent = new int[n + 1];
+        setParent(1);
+
+        for (int i = 2; i <= n; i++) {
+            System.out.println(parent[i]);
+        }
+    }
+
+    // 트리의 노드를 각 한 번씩 방문하고, 각 간선을 한 번씩 검사함. 트리의 간선 수는 n-1개이므로 DFS 시간복잡도는 O(n)
+    private static void setParent(int num) {
+        for (int i = 0; i < relation[num].size(); i++) {
+            int next = relation[num].get(i);
+
+            if (!visit[next]) {
+                parent[next] = num;
+                visit[next] = true;
+                setParent(next);
+            }
+        }
+    }
+}


### PR DESCRIPTION
늦어서 죄송함니다 🥲 

## 11725: 트리의 부모 찾기
> 소요시간: 20분
> 메모리: 76820 KB
> 시간: 1136 ms
> 시간복잡도: O(N)
### 간단한 풀이
- 루트 노드부터 dfs()를 수행해, 각 자식의 parent를 현재 num으로 설정해줌
- parent 배열 출력  

## 1991: 트리 순회
> 소요시간: 25분
> 메모리: 14296 KB
> 시간: 108 ms
> 시간복잡도: O(N)
### 간단한 풀이
- System.out.print() 위치만 변경해줘서, 전위 + 후위 + 중위 순회 를 구현함 

## 2217: 로프
> 소요시간: 30분
> 메모리: 29752 KB
> 시간: 344 ms
> 시간복잡도: O(NlogN)
### 간단한 풀이
- 선택한 로프 중 가장 작은 중량을 가진 로프 X 선택한 로프 개수 => 최대 중량 
- 로프를 내림차순 정렬한 뒤 (실제로는 오름차순으로 한 뒤 역순으로 접근함) 로프를 추가 선택하고, 최대 중량을 구하는 로직을 for문 안에 구현함 
```java
for (int i = n - 1; i >= 0; i--) {
    int w = count * rope[i];
    if (w > maxW) {
        maxW = w;
    }
    count++;
}
```

## 1026: 보물
> 소요시간: 5분
> 메모리: 14304 KB
> 시간: 128 ms
> 시간복잡도: O(NlogN)
### 간단한 풀이
- A 배열은 오름차순 정렬, B 배열은 내림차순 정렬을 한 뒤, 같은 인덱스에 있는 배열 값을 서로 곱해주면 만들 수 있는 s의 최소 값이 만들어 진다.
