### PR TITLE
240722

### DIFF
--- a/src/baekjoon/부분합_1806.java
+++ b/src/baekjoon/부분합_1806.java
@@ -1,0 +1,64 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 10 ≤ N < 100,000
+ * 0 < S ≤ 100,000,000
+ * 시간 제한: 1초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(투포인터 탐색) = O(N) = O(N)
+ * 메모리: 23912 KB, 시간: 296 ms
+ **************************************************************************************/
+
+public class 부분합_1806 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int s = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        int[] arr = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int left = 0;
+        int right = 0;
+        int sum = arr[left]; // 부분합
+
+        int minLength = Integer.MAX_VALUE;
+
+        while (left <= right) { // O(N)
+            if (right == n) break;
+
+            if (sum < s) { // sum이 s보다 작은 경우
+                right++;
+                if (right < n)
+                    sum += arr[right];
+            } else { // sum이 s보다 같거나 큰 경우
+                sum -= arr[left];
+                minLength = Math.min(right - left + 1, minLength); // 부분합이 s 이상인 경우, 가장 짧은 것의 길이 갱신
+
+                if (left == right) { // 만약 left와 right가 동시에 한 개의 값을 가리키고 있다면 두 인덱스 모두 + 1
+                    left++;
+                    right++;
+                    if (right < n)
+                        sum += arr[right];
+                } else { // left와 right가 서로 다른 값을 가리키고 있다면 left만 + 1 해주어 부분합을 감소시킴
+                    left++;
+                }
+            }
+        }
+
+        if (minLength == Integer.MAX_VALUE) {
+            minLength = 0;
+        }
+
+        System.out.println(minLength);
+    }
+}

--- a/src/baekjoon/수고르기_2230.java
+++ b/src/baekjoon/수고르기_2230.java
@@ -1,0 +1,55 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ N ≤ 100,000
+ * 0 ≤ M ≤ 2,000,000,000
+ * 0 ≤ |A[i]| ≤ 1,000,000,000
+ * 시간 제한: 2초
+ *
+ * 만약, 이중 for문을 이용해 구한다면 O(N^2) = O((10^10) > O(10^9) 시간초과 발생
+ * 따라서, 투포인터를 이용한 O(N) 로직 필요
+ *      투포인터 left와 right는 배열 a를 한 번 순회하고, 최악의 경우 배열 끝까지 가기 때문에 O(n) 시간복잡도 가짐
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(정렬 + 투포인터 탐색) = O(NlogN + N) = O(NlogN)
+ * 메모리: 32108 KB, 시간: 416 ms
+ **************************************************************************************/
+
+public class 수고르기_2230 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[] a = new int[n]; // n+1로 할당했더니, sort 시, 맨 뒤에 있던 0이 포함되어 원하는 로직을 수행할 수 없었음! (주의)
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            a[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(a); // O(NlogN)
+
+        int left = 0;
+        int right = 1;
+        int diff = a[right] - a[left];
+        int minDiff = Integer.MAX_VALUE;
+
+        while (left <= right) { // O(N)
+            if (right == n) break;
+            diff = a[right] - a[left];
+
+            if (diff < m) { // m보다 작다면
+                right++;
+            } else if (diff >= m) { // m보다 크다면
+                minDiff = Math.min(minDiff, diff);
+                left++;
+            }
+        }
+        System.out.println(minDiff);
+    }
+}


### PR DESCRIPTION
## 2230: 수 고르기
> 소요시간: 25분
> 메모리: 32108 KB
> 시간: 416 ms
> 시간복잡도: O(정렬 + 투포인터 탐색) = O(NlogN + N) = O(NlogN)
### 간단한 풀이
- a[] 배열을 정렬시킴
- 정렬된 배열을 가지고
   1. 두 수의 차이가 m보다 작다면 right 포인터를 + 1
   2. 두 수의 차이가 m보다 크다면 left 포인터를 + 1

## 1806: 부분 합
> 소요시간: 20분
> 메모리: 23912 KB
> 시간: 296 ms
> 시간복잡도: O(투포인터 탐색) = O(N) = O(N)
### 간단한 풀이
- 구간합을 구하는 문제이므로, arr 배열은 정렬될 필요가 없음
- 구간합을 저장하는 sum 변수가 s 보다 작다면, right 포인터 + 1
- sum 변수가 s 보다 크거나 같을 경우,
   1.  right == left 라면, right와 left 모두 + 1
   2. right != left 라면, left만 + 1 