### PR TITLE
240717 + LinkedHashSet + String 관련 메서드

### DIFF
--- a/src/baekjoon/나는야_포켓몬_마스터_이다솜_1620.java
+++ b/src/baekjoon/나는야_포켓몬_마스터_이다솜_1620.java
@@ -1,0 +1,57 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ n, m ≤ 100,000
+ * 시간 제한: 2초
+ *
+ * [알게 된 표현]
+ * 1. for (char c : string.toCharArray()) { } // String 문자열을 순회하며 체크
+ * 2. if (Character.isDigit(char)) { } // char 에 숫자 0~9가 포함되어 있는지 체크하는 메서드
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N + M)
+ * 메모리: 64384 KB, 시간: 1144 ms
+ **************************************************************************************/
+
+public class 나는야_포켓몬_마스터_이다솜_1620 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        Map<String, Integer> poketmon = new HashMap<>();
+        Map<Integer, String> poketmonNum = new HashMap<>();
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        for (int i = 1; i <= n; i++) { // O(n)
+            st = new StringTokenizer(br.readLine());
+            String name = st.nextToken();
+
+            poketmon.put(name, i); // O(1)
+            poketmonNum.put(i, name); // O(1)
+        }
+
+        for (int i = 0; i < m; i++) { // O(m)
+            st = new StringTokenizer(br.readLine());
+
+            String question = st.nextToken();
+            boolean isNumber = false;
+
+            for (char q : question.toCharArray()) { // toCharArray()를 사용하지 않으면 question이 String이라 해당 문법 사용할 수 없다고 뜸
+                if (Character.isDigit(q)) {
+                    isNumber = true;
+                    break;
+                }
+            }
+
+            if (isNumber) {
+                System.out.println(poketmonNum.get(Integer.parseInt(question))); // O(1)
+            } else {
+                System.out.println(poketmon.get(question)); // O(1)
+            }
+        }
+    }
+}

--- a/src/baekjoon/수강신청_13414.java
+++ b/src/baekjoon/수강신청_13414.java
@@ -1,0 +1,55 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ K ≤ 100,000
+ * 1 ≤ L ≤ 500,000
+ * 시간 제한: 1초
+ *
+ * [알게 된 개념]
+ * 1. LinkedHashSet
+ *   - HashSet은 삽입 순서를 유지하지 않기 때문에, 삽입 순서를 유지하고 싶다면 LinkedHashSet을 사용해야 함
+ *   - 시간 복잡도
+ *     - 삽입: O(1) (add)
+ *     - 삭제: O(1) (remove)
+ *     - 탐색: O(1) (contains)
+ *     - 순회: O(N) (iterator)
+ *   - 이 자료구조는 삽입 순서를 유지하면서도 HashSet의 상수 시간 성능을 제공!
+ *   - 그렇기 때문에, 추가적으로 순서 유지를 위한 링크드 리스트를 관리하므로 약간의 메모리 오버헤드 발생함
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(l + k)
+ * 메모리: 88884 KB, 시간: 1460 ms
+ **************************************************************************************/
+
+public class 수강신청_13414 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int k = Integer.parseInt(st.nextToken());
+        int l = Integer.parseInt(st.nextToken());
+
+        Set<String> set = new LinkedHashSet<>(); // 삽입 순서를 유지하는 Set의 구현체
+
+        for (int i = 0; i < l; i++) {       // O(l)
+            st = new StringTokenizer(br.readLine());
+            String number = st.nextToken();
+
+            if (set.contains(number)) {     // O(1)
+                set.remove(number);         // O(1)
+                set.add(number);            // O(1)
+            } else {
+                set.add(number);
+            }
+        }
+
+        int count = 0;
+        for (String number : set) {         // O(k)
+            if (count == k) break;
+            System.out.println(number);
+            count++;
+        }
+    }
+}

--- a/src/baekjoon/회사에_있는_사람_7785.java
+++ b/src/baekjoon/회사에_있는_사람_7785.java
@@ -26,7 +26,7 @@ public class 회사에_있는_사람_7785 {
             String name = st.nextToken();
             String status = st.nextToken();
 
-            if (status.equals("leave")) {
+            if (status.equals("leave")) { // 자바의 문자열 비교
                 log.put(name, false); // 평균: O(1)
             } else {
                 log.put(name, true); // O(1)

--- a/src/baekjoon/회사에_있는_사람_7785.java
+++ b/src/baekjoon/회사에_있는_사람_7785.java
@@ -1,0 +1,42 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 2 ≤ n ≤ 10^6
+ * 시간 제한: 1초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N)
+ * 메모리: 51044 KB, 시간: 1328 ms
+ **************************************************************************************/
+
+public class 회사에_있는_사람_7785 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        // 역순 Comparator 를 사용하여 TreeMap 생성
+        Map<String, Boolean> log = new TreeMap<>(Comparator.reverseOrder());
+
+        int n = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < n; i++) { // O(n)
+            st = new StringTokenizer(br.readLine());
+            String name = st.nextToken();
+            String status = st.nextToken();
+
+            if (status.equals("leave")) {
+                log.put(name, false); // 평균: O(1)
+            } else {
+                log.put(name, true); // O(1)
+            }
+        }
+
+        log.forEach((key, value) -> { // O(n)
+            if (value) {
+                System.out.println(key);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## 7785: 회사에 있는 사람
> 소요시간: 15분
> 메모리: 51044 KB
> 시간: 1328 ms
> 시간복잡도: O(N)
### 간단한 풀이
- TreeMap 을 사용해 정렬된 HashMap을 이용해, 시간 복잡도를 줄임 
- TreeMap 에 (회사원, 출퇴근 상태)를 넣고 출퇴근 상태(status)가 false 인 경우, 퇴근으로 판단
- TreeMap을 선형 탐색 해, 출퇴근 상태가 true인 회사원만 출력 

### 알게 된 메서드
- TreeMap의 역순 정렬 
  ```java
  Map<String, Boolean> log = new TreeMap<>(Comparator.reverseOrder());
  ```
- Map의 선형 탐색 
  ```java
  log.forEach((key, value) -> { // O(n)
      if (value) {
          System.out.println(key);
      }
  });
  ```
## 1620: 나는야 포켓몬 마스터 이다솜
> 소요시간: 15분
> 메모리: 64384 KB
> 시간: 1144 ms
> 시간복잡도: O(N + M)
### 간단한 풀이 
- 포켓몬 번호를 Key로 가지는 HashMap과 포켓몬 이름을 Key로 가지는 HashMap 두 가지를 선언
  - 이렇게 구현한 이유: 번호 혹은 이름을 입력받았을 때, 모든 경우에 O(1) 시간에 검색되기 위해
### 알게 된 메서드 
- String 문자열 속 문자를 Char로 접근하는 방법
  ```java
   for (char c : string.toCharArray()) { } 
  ```
- char에 숫자가 포함되어 있는지 확인하는 방법
  ```java
  if (Character.isDigit(char)) { } 
  ```

## 13414: 수강 신청 
> 소요시간: 10분
> 메모리: 88884 KB
> 시간: 1460 ms
> 시간복잡도: O(l + k)
### 간단한 풀이 
- LinkedHashSet 을 사용해, 입력되는 학번 순서를 유지하고 상위 k개의 학번을 출력 
### 알게 된 자료구조 
- LinkedHashSet
  - 삽입 순서를 유지하는 Set의 구현체 (HashSet은 삽입 순서 유지 X)
  - 시간 복잡도 
    - 삽입: O(1) (add) 
    - 삭제: O(1) (remove)
    - 탐색: O(1) (contains)
    - 순회: O(N) (iterator)
  - 이 자료구조는 삽입 순서를 유지하면서도 HashSet의 상수 시간 성능을 제공!
  - 그렇기 때문에, 추가적으로 순서 유지를 위한 링크드 리스트를 관리하므로 약간의 메모리 오버헤드 발생함