### PR TITLE
240726

### DIFF
--- a/src/baekjoon/경사로_14890.java
+++ b/src/baekjoon/경사로_14890.java
@@ -3,10 +3,23 @@ package baekjoon;
 import java.io.*;
 import java.util.*;
 
+/**************************************************************************************
+ * 1 ≤ N ≤ 100,000
+ *
+ * [회고]
+ * 이 문제는 몇 번의 비교가 필요한지 구하는 문제이기 때문에,
+ * 만약 카드 묶음이 1개라면 비교할 필요가 없음
+ * 따라서 답은 0이 출력되어야 함
+ * => 문제를 잘 읽자..
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(NlogN)
+ * 메모리: 25460 KB, 시간: 368 ms
+ **************************************************************************************/
+
 public class 경사로_14890 {
     private static int N, L;
-    private static int[][] map;
-    private static boolean[][] slope;
+    private static int[][] map;         // 칸의 높이 저장
+    private static boolean[][] slope;   // 슬로프 설치 여부 저장
 
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -33,11 +46,13 @@ public class 경사로_14890 {
             boolean isRoad = true;
 
             for (int j = 1; j < N; j++) {
-                int prev = map[j - 1][i];
-                int cur = map[j][i];
+                int prev = map[j - 1][i];   // 이전 칸의 길 높이
+                int cur = map[j][i];        // 현재 칸의 길 높이
 
-                if (slope[j][i]) continue; // 이미 슬로프가 놓여있다면, 슬로프 고려 대상 아님
+                // 이미 슬로프 설치되어 있다면, 슬로프 설치를 고려하지 않음
+                if (slope[j][i]) continue;
 
+                // 슬로프 설치할 수 있는 지 체크
                 if (!isLayColumnSlope(j, i, prev, cur)) {
                     isRoad = false;
                     break;
@@ -46,7 +61,7 @@ public class 경사로_14890 {
             if (isRoad) roadCount++;
         }
 
-        // slope 초기화
+        // slope 초기화 (길은 행 or 열로 이루어져있기 때문에 이전에 설치된 슬로프가 다른 길의 슬로프에 영향을 줄 수 없음)
         slope = new boolean[N][N];
 
         // 행 - 길의 갯수를 체크
@@ -57,8 +72,10 @@ public class 경사로_14890 {
                 int prev = map[i][j - 1];
                 int cur = map[i][j];
 
+                // 이미 슬로프 설치되어 있다면, 슬로프 설치를 고려하지 않음
                 if (slope[i][j]) continue;
 
+                // 슬로프 설치할 수 있는 지 체크
                 if (!isLayRowSlope(i, j, prev, cur)) {
                     isRoad = false;
                     break;
@@ -79,12 +96,13 @@ public class 경사로_14890 {
             for (int diff = 1; diff <= L; diff++) {
                 int ny = y - diff;
 
+                // 슬로프를 설치할 수 없는 조건 (이른 종료)
                 if (oob(x, ny)) return false;
                 if (map[x][ny] != prev) return false;
                 if (slope[x][ny]) return false;
             }
 
-            // 슬로프 설치 가능
+            // 슬로프 설치 가능한 경우이기에 슬로프 설치
             for (int diff = 1; diff <= L; diff++) {
                 int ny = y - diff;
                 slope[x][ny] = true;
@@ -93,32 +111,34 @@ public class 경사로_14890 {
             for (int diff = 1; diff <= L; diff++) {
                 int ny = y + diff - 1;
 
+                // 슬로프를 설치할 수 없는 조건 (이른 종료)
                 if (oob(x, ny)) return false;
                 if (map[x][ny] != cur) return false;
                 if (slope[x][ny]) return false;
             }
 
-            // 슬로프 설치 가능
+            // 슬로프 설치 가능한 경우이기에 슬로프 설치
             for (int diff = 1; diff <= L; diff++) {
                 int ny = y + diff - 1;
                 slope[x][ny] = true;
             }
-        } else return prev <= cur + 1 && prev + 1 >= cur;
+        } else return prev <= cur + 1 && prev + 1 >= cur; // prev와 cur의 차이가 2 이상이라면, false 리턴
 
         return true;
     }
 
     private static boolean isLayColumnSlope(int x, int y, int prev, int cur) {
-        if (prev + 1 == cur) { // (1, 2) 처럼 올라가는 형태
+        if (prev + 1 == cur) { // (1, 1) 처럼 올라가는 형태
             for (int diff = 1; diff <= L; diff++) {
                 int nx = x - diff;
 
+                // 슬로프를 설치할 수 없는 조건 (이른 종료)
                 if (oob(nx, y)) return false;
                 if (map[nx][y] != prev) return false;
                 if (slope[nx][y]) return false;
             }
 
-            // 슬로프 설치 가능
+            // 슬로프 설치 가능한 경우이기에 슬로프 설치
             for (int diff = 1; diff <= L; diff++) {
                 int nx = x - diff;
                 slope[nx][y] = true;
@@ -127,17 +147,18 @@ public class 경사로_14890 {
             for (int diff = 1; diff <= L; diff++) {
                 int nx = x + diff - 1;
 
+                // 슬로프를 설치할 수 없는 조건 (이른 종료)
                 if (oob(nx, y)) return false;
                 if (map[nx][y] != cur) return false;
                 if (slope[nx][y]) return false;
             }
 
-            // 슬로프 설치 가능
+            // 슬로프 설치 가능한 경우이기에 슬로프 설치
             for (int diff = 1; diff <= L; diff++) {
                 int nx = x + diff - 1;
                 slope[nx][y] = true;
             }
-        } else return prev <= cur + 1 && prev + 1 >= cur;
+        } else return prev <= cur + 1 && prev + 1 >= cur; // prev와 cur의 차이가 2 이상이라면, false 리턴
 
         return true;
     }

--- a/src/baekjoon/경사로_14890.java
+++ b/src/baekjoon/경사로_14890.java
@@ -4,16 +4,20 @@ import java.io.*;
 import java.util.*;
 
 /**************************************************************************************
- * 1 ≤ N ≤ 100,000
+ * 2 ≤ N ≤ 100
+ * 1 ≤ L ≤ N
  *
- * [회고]
- * 이 문제는 몇 번의 비교가 필요한지 구하는 문제이기 때문에,
- * 만약 카드 묶음이 1개라면 비교할 필요가 없음
- * 따라서 답은 0이 출력되어야 함
- * => 문제를 잘 읽자..
+ * 1. 0열 ~ N-1열까지, 길의 개수를 체크
+ * 2. 0행 ~ N-1행까지, 길의 개수를 체크
+ * 3. 길이 될 수 있는지 체크
+ *      - 모든 칸을 체크하며,
+ *          - 단차 차이가 있어 슬로프를 놓아야하는데 조건에 맞지 않아 슬로프를 놓지 못한다면 => 길이 될 수 없다 판정
+ *          - 단차 차이가 없어 슬로프를 놓지 않아도 되는 경우거나, 슬로프를 놓을 수 있다면 => 길이 될 수 있다 판정
+ *
+ * 위 과정을 수행하며 길의 개수를 체크한 뒤, 출력
  *------------------------------------------------------------------------------------
- * 시간복잡도: O(NlogN)
- * 메모리: 25460 KB, 시간: 368 ms
+ * 시간복잡도: O(N * N * L)
+ * 메모리: 14920 KB, 시간: 156 ms
  **************************************************************************************/
 
 public class 경사로_14890 {
@@ -42,7 +46,7 @@ public class 경사로_14890 {
         int roadCount = 0;
 
         // 열 - 길의 갯수를 체크
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < N; i++) { // O(NN)
             boolean isRoad = true;
 
             for (int j = 1; j < N; j++) {
@@ -53,7 +57,7 @@ public class 경사로_14890 {
                 if (slope[j][i]) continue;
 
                 // 슬로프 설치할 수 있는 지 체크
-                if (!isLayColumnSlope(j, i, prev, cur)) {
+                if (!isLayColumnSlope(j, i, prev, cur)) { // O(L)
                     isRoad = false;
                     break;
                 }
@@ -65,7 +69,7 @@ public class 경사로_14890 {
         slope = new boolean[N][N];
 
         // 행 - 길의 갯수를 체크
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < N; i++) { // O(NN)
             boolean isRoad = true;
 
             for (int j = 1; j < N; j++) {
@@ -91,7 +95,7 @@ public class 경사로_14890 {
         System.out.println(roadCount);
     }
 
-    private static boolean isLayRowSlope(int x, int y, int prev, int cur) {
+    private static boolean isLayRowSlope(int x, int y, int prev, int cur) { // O(L)
         if (prev + 1 == cur) { // (1, 2) 처럼 올라가는 형태
             for (int diff = 1; diff <= L; diff++) {
                 int ny = y - diff;
@@ -127,7 +131,7 @@ public class 경사로_14890 {
         return true;
     }
 
-    private static boolean isLayColumnSlope(int x, int y, int prev, int cur) {
+    private static boolean isLayColumnSlope(int x, int y, int prev, int cur) { // O(L)
         if (prev + 1 == cur) { // (1, 1) 처럼 올라가는 형태
             for (int diff = 1; diff <= L; diff++) {
                 int nx = x - diff;

--- a/src/baekjoon/경사로_14890.java
+++ b/src/baekjoon/경사로_14890.java
@@ -96,8 +96,11 @@ public class 경사로_14890 {
     }
 
     private static boolean isLayRowSlope(int x, int y, int prev, int cur) { // O(L)
+        // prev: 이전 칸의 높이
+        // cur: 현재 칸의 높이
+        // x, y: 현재 칸의 인덱스
         if (prev + 1 == cur) { // (1, 2) 처럼 올라가는 형태
-            for (int diff = 1; diff <= L; diff++) {
+            for (int diff = 1; diff <= L; diff++) { // L 개의 칸에 대해서, 슬로프를 놓을 수 있을 지 조건 체크
                 int ny = y - diff;
 
                 // 슬로프를 설치할 수 없는 조건 (이른 종료)
@@ -108,12 +111,12 @@ public class 경사로_14890 {
 
             // 슬로프 설치 가능한 경우이기에 슬로프 설치
             for (int diff = 1; diff <= L; diff++) {
-                int ny = y - diff;
+                int ny = y - diff; // 체크할 칸
                 slope[x][ny] = true;
             }
         } else if (prev == cur + 1) { // (2, 1) 처럼 내려가는 형태
-            for (int diff = 1; diff <= L; diff++) {
-                int ny = y + diff - 1;
+            for (int diff = 1; diff <= L; diff++) { // L 개의 칸에 대해서, 슬로프를 놓을 수 있을 지 조건 체크
+                int ny = y + diff - 1; // 체크할 칸
 
                 // 슬로프를 설치할 수 없는 조건 (이른 종료)
                 if (oob(x, ny)) return false;
@@ -132,9 +135,12 @@ public class 경사로_14890 {
     }
 
     private static boolean isLayColumnSlope(int x, int y, int prev, int cur) { // O(L)
-        if (prev + 1 == cur) { // (1, 1) 처럼 올라가는 형태
-            for (int diff = 1; diff <= L; diff++) {
-                int nx = x - diff;
+        // prev: 이전 칸의 높이
+        // cur: 현재 칸의 높이
+        // x, y: 현재 칸의 인덱스
+        if (prev + 1 == cur) { // (1, 2) 처럼 올라가는 형태
+            for (int diff = 1; diff <= L; diff++) { // L 개의 칸에 대해서, 슬로프를 놓을 수 있을 지 조건 체크
+                int nx = x - diff; // 체크할 칸
 
                 // 슬로프를 설치할 수 없는 조건 (이른 종료)
                 if (oob(nx, y)) return false;
@@ -148,8 +154,8 @@ public class 경사로_14890 {
                 slope[nx][y] = true;
             }
         } else if (prev == cur + 1) { // (2, 1) 처럼 내려가는 형태
-            for (int diff = 1; diff <= L; diff++) {
-                int nx = x + diff - 1;
+            for (int diff = 1; diff <= L; diff++) { // L 개의 칸에 대해서, 슬로프를 놓을 수 있을 지 조건 체크
+                int nx = x + diff - 1; // 체크할 칸
 
                 // 슬로프를 설치할 수 없는 조건 (이른 종료)
                 if (oob(nx, y)) return false;

--- a/src/baekjoon/경사로_14890.java
+++ b/src/baekjoon/경사로_14890.java
@@ -1,0 +1,148 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+public class 경사로_14890 {
+    private static int N, L;
+    private static int[][] map;
+    private static boolean[][] slope;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+
+        map = new int[N][N];
+        slope = new boolean[N][N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int roadCount = 0;
+
+        // 열 - 길의 갯수를 체크
+        for (int i = 0; i < N; i++) {
+            boolean isRoad = true;
+
+            for (int j = 1; j < N; j++) {
+                int prev = map[j - 1][i];
+                int cur = map[j][i];
+
+                if (slope[j][i]) continue; // 이미 슬로프가 놓여있다면, 슬로프 고려 대상 아님
+
+                if (!isLayColumnSlope(j, i, prev, cur)) {
+                    isRoad = false;
+                    break;
+                }
+            }
+            if (isRoad) roadCount++;
+        }
+
+        // slope 초기화
+        slope = new boolean[N][N];
+
+        // 행 - 길의 갯수를 체크
+        for (int i = 0; i < N; i++) {
+            boolean isRoad = true;
+
+            for (int j = 1; j < N; j++) {
+                int prev = map[i][j - 1];
+                int cur = map[i][j];
+
+                if (slope[i][j]) continue;
+
+                if (!isLayRowSlope(i, j, prev, cur)) {
+                    isRoad = false;
+                    break;
+                }
+            }
+
+            if (isRoad) roadCount++;
+
+            for (int j = 0; j < N; j++) {
+                slope[i][j] = false;
+            }
+        }
+        System.out.println(roadCount);
+    }
+
+    private static boolean isLayRowSlope(int x, int y, int prev, int cur) {
+        if (prev + 1 == cur) { // (1, 2) 처럼 올라가는 형태
+            for (int diff = 1; diff <= L; diff++) {
+                int ny = y - diff;
+
+                if (oob(x, ny)) return false;
+                if (map[x][ny] != prev) return false;
+                if (slope[x][ny]) return false;
+            }
+
+            // 슬로프 설치 가능
+            for (int diff = 1; diff <= L; diff++) {
+                int ny = y - diff;
+                slope[x][ny] = true;
+            }
+        } else if (prev == cur + 1) { // (2, 1) 처럼 내려가는 형태
+            for (int diff = 1; diff <= L; diff++) {
+                int ny = y + diff - 1;
+
+                if (oob(x, ny)) return false;
+                if (map[x][ny] != cur) return false;
+                if (slope[x][ny]) return false;
+            }
+
+            // 슬로프 설치 가능
+            for (int diff = 1; diff <= L; diff++) {
+                int ny = y + diff - 1;
+                slope[x][ny] = true;
+            }
+        } else return prev <= cur + 1 && prev + 1 >= cur;
+
+        return true;
+    }
+
+    private static boolean isLayColumnSlope(int x, int y, int prev, int cur) {
+        if (prev + 1 == cur) { // (1, 2) 처럼 올라가는 형태
+            for (int diff = 1; diff <= L; diff++) {
+                int nx = x - diff;
+
+                if (oob(nx, y)) return false;
+                if (map[nx][y] != prev) return false;
+                if (slope[nx][y]) return false;
+            }
+
+            // 슬로프 설치 가능
+            for (int diff = 1; diff <= L; diff++) {
+                int nx = x - diff;
+                slope[nx][y] = true;
+            }
+        } else if (prev == cur + 1) { // (2, 1) 처럼 내려가는 형태
+            for (int diff = 1; diff <= L; diff++) {
+                int nx = x + diff - 1;
+
+                if (oob(nx, y)) return false;
+                if (map[nx][y] != cur) return false;
+                if (slope[nx][y]) return false;
+            }
+
+            // 슬로프 설치 가능
+            for (int diff = 1; diff <= L; diff++) {
+                int nx = x + diff - 1;
+                slope[nx][y] = true;
+            }
+        } else return prev <= cur + 1 && prev + 1 >= cur;
+
+        return true;
+    }
+
+    private static boolean oob(int x, int y) {
+        return x < 0 || y < 0 || x >= N || y >= N;
+    }
+}

--- a/src/baekjoon/절댓값힙_11286.java
+++ b/src/baekjoon/절댓값힙_11286.java
@@ -7,8 +7,8 @@ import java.util.*;
  * 1 ≤ N ≤ 100,000 = 10^5
  * -2^31 < x < 2^31
  *------------------------------------------------------------------------------------
- * 시간복잡도:
- * 메모리:  KB, 시간:  ms
+ * 시간복잡도: O(NlogN)
+ * 메모리: 25028 KB, 시간: 328 ms
  **************************************************************************************/
 
 public class 절댓값힙_11286 {
@@ -42,10 +42,10 @@ public class 절댓값힙_11286 {
 
             if (x == 0) {
                 if (pq.isEmpty()) sb.append("0").append("\n");
-                else sb.append(pq.poll().origin).append("\n");
+                else sb.append(pq.poll().origin).append("\n"); // poll(): O(logN)
             } else {
                 // 배열에 x를 넣는 연산
-                pq.offer(new Number(Math.abs(x), x));
+                pq.offer(new Number(Math.abs(x), x)); // offer(): O(logN)
             }
         }
 

--- a/src/baekjoon/절댓값힙_11286.java
+++ b/src/baekjoon/절댓값힙_11286.java
@@ -1,0 +1,54 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ N ≤ 100,000 = 10^5
+ * -2^31 < x < 2^31
+ *------------------------------------------------------------------------------------
+ * 시간복잡도:
+ * 메모리:  KB, 시간:  ms
+ **************************************************************************************/
+
+public class 절댓값힙_11286 {
+    private static class Number implements Comparable<Number> {
+        int abs;
+        int origin;
+
+        Number(int abs, int origin) {
+            this.abs = abs;
+            this.origin = origin;
+        }
+
+        @Override
+        public int compareTo(Number o) {
+            if (this.abs == o.abs) {
+                return Integer.compare(this.origin, o.origin); // 작은 거 먼저 (오름차순)
+            }
+            return Integer.compare(this.abs, o.abs); // 작은 거 먼저 (오름차순)
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int n = Integer.parseInt(br.readLine());
+
+        PriorityQueue<Number> pq = new PriorityQueue<>(); // 최소 힙
+        while (n-- > 0) { // O(N)
+            int x = Integer.parseInt(br.readLine());
+
+            if (x == 0) {
+                if (pq.isEmpty()) sb.append("0").append("\n");
+                else sb.append(pq.poll().origin).append("\n");
+            } else {
+                // 배열에 x를 넣는 연산
+                pq.offer(new Number(Math.abs(x), x));
+            }
+        }
+
+        System.out.print(sb);
+    }
+}

--- a/src/baekjoon/카드_정렬하기_1715.java
+++ b/src/baekjoon/카드_정렬하기_1715.java
@@ -1,0 +1,54 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 1 ≤ N ≤ 100,000
+ *
+ * [회고]
+ * 이 문제는 몇 번의 비교가 필요한지 구하는 문제이기 때문에,
+ * 만약 카드 묶음이 1개라면 비교할 필요가 없음
+ * 따라서 답은 0이 출력되어야 함
+ * => 문제를 잘 읽자..
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(NlogN)
+ * 메모리: 25460 KB, 시간: 368 ms
+ **************************************************************************************/
+
+public class 카드_정렬하기_1715 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        // 무조건 작은 애들 먼저 합쳐주는 게 이득? ㅇㅇ
+        int n = Integer.parseInt(br.readLine());
+        PriorityQueue<Integer> pq = new PriorityQueue<>(); // 최소 힙
+
+        while (n-- > 0) {
+            int card = Integer.parseInt(br.readLine());
+            pq.offer(card);
+        }
+
+        int totalSum = 0; // 총 비교 횟수
+
+        if (pq.size() > 1) {
+            int count = 0; // 현재 몇 개의 카드 묶음을 섞었는지 저장하는 변수. 2를 넘지 않는다.
+            int sum = 0;
+
+            while (!pq.isEmpty()) { // O(N)
+                if (count <= 1) {
+                    sum += pq.poll(); // O(logN)
+                    count++;
+                } else { // 두 개의 묶음이 모인 경우
+                    pq.offer(sum); // 다시 우선 순위 큐에 넣어서 비교 대상으로 만들기 // O(logN)
+                    totalSum += sum;
+                    sum = 0;
+                    count = 0;
+                }
+            }
+            totalSum += sum;
+        }
+
+        System.out.println(totalSum);
+    }
+}


### PR DESCRIPTION
## 11286: 절댓값 힙
> 소요시간: 15분 
> 메모리: 25028 KB
> 시간: 328 ms
> 시간복잡도: O(NlogN)
### 간단한 풀이
- PriorityQueue 사용해서 풀이함
    - 1순위: 절댓값이 작은 수, 2순위: 작은 수 => 우선순위에 맞춰 최소힙에서 나오게 함 
    - 드디어 compareTo를 정상적으로 활용하다.. 🫠  

## 1715: 카드 정렬하기
> 소요시간: 25분
> 메모리: 25460 KB
> 시간: 368 ms
> 시간복잡도: O(NlogN)
### 간단한 풀이
- 최소 힙에서 A와 B 두 묶음을 꺼냈다면, A + B 값을 totalSum 변수에 더해주고 A + B 값을 최소힙에도 넣어줌
    - 최소 힙에 3개 이상의 카드 묶음이 들어가 있다면, 1 + 2 + ((1 + 2) + 3) <- 이렇게 더해주는 과정이 필요하기 때문
- [주의] 카드 묶음이 1개만 들어갔다면 출력은 0으로 해줘야함. 왜냐하면 총 비교 횟수를 묻는 문제이므로 묶음이 1개라면 비교할 필요가 없음 

## 14890: 경사로
> 소요시간: 1시간 10분 
> 메모리: 14920 KB
> 시간: 156 ms
> 시간복잡도: O(N * N * L)
### 간단한 풀이
1. 0열 ~ N-1열까지, 길의 개수를 체크
2. 0행 ~ N-1행까지, 길의 개수를 체크
3. 길이 될 수 있는지 체크
    - 모든 칸을 체크하며,
        - 단차 차이가 있어 슬로프를 놓아야하는데 조건에 맞지 않아 슬로프를 놓지 못한다면 => 길이 될 수 없다 판정
        - 단차 차이가 없어 슬로프를 놓지 않아도 되는 경우거나, 슬로프를 놓을 수 있다면 => 길이 될 수 있다 판정    

위 과정을 수행하며 길의 개수를 체크한 뒤, 출력
 
