### PR TITLE
240730

### DIFF
--- a/src/baekjoon/듣보잡_1764.java
+++ b/src/baekjoon/듣보잡_1764.java
@@ -1,0 +1,48 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * N, M <= 500,000
+ *
+ * 시간 제한: 1초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N + MlogM)
+ * 메모리: 25928 KB, 시간: 312 ms
+ **************************************************************************************/
+
+public class 듣보잡_1764 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        HashSet<String> set = new HashSet<>();
+
+        for (int i = 0; i < n; i++) { // O(N)
+            String name = br.readLine();
+            set.add(name);
+        }
+
+        List<String> list = new ArrayList<>();
+        for (int i = 0; i < m; i++) { // O(M)
+            String name = br.readLine();
+
+            if (set.contains(name)) { // O(1)
+                list.add(name);
+            }
+        }
+
+        sb.append(list.size()).append("\n");
+        Collections.sort(list); // O(MlogM)
+
+        for (String str : list) {
+            sb.append(str).append("\n");
+        }
+        System.out.print(sb);
+    }
+}

--- a/src/baekjoon/트리_4803.java
+++ b/src/baekjoon/트리_4803.java
@@ -1,0 +1,97 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * N ≤ 500
+ * M <= N(N-1)/2
+ * 시간 제한: 1초
+ *
+ * DFS를 활용해, 이미 방문한 노드를 또 방문할 때 사이클이 발생한다고 판단
+ * 하지만 이때, 또 방문한 노드가 노드의 부모인 경우에는 사이클이라고 판단하지 않음
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(T * (N + M)) (이때, T는 무한 루프(while문) 종료되기 전까지 호출된 횟수라 가정)
+ * 메모리: 61884 KB, 시간: 448 ms
+ **************************************************************************************/
+
+public class 트리_4803 {
+    private static boolean[] visit;
+    private static List<Integer>[] edge;
+    private static StringBuilder sb;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        sb = new StringBuilder();
+
+        int testNum = 1;
+
+        while (true) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());
+            int m = Integer.parseInt(st.nextToken());
+
+            if (n == 0 && m == 0) break;
+
+            visit = new boolean[n + 1];
+            edge = new ArrayList[n + 1];
+
+            for (int i = 1; i <= n; i++) {
+                edge[i] = new ArrayList<>();
+            }
+
+            while (m-- > 0) { // O(M)
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+
+                // 방향이 없는 간선이라면 꼭 a, b 모두 간선 정보를 저장해주기
+                edge[a].add(b);
+                edge[b].add(a);
+            }
+
+            int treeCount = 0;
+
+            for (int i = 1; i <= n; i++) {  // O(N + M)
+                if (visit[i]) continue;
+                visit[i] = true;
+
+                if (!dfs(i, i)) {
+                    treeCount++;
+                }
+            }
+            printTree(treeCount, testNum++);
+        }
+        System.out.print(sb);
+    }
+
+    public static void printTree(int treeCount, int caseNum) {
+        sb.append("Case ").append(caseNum).append(": ");
+        if (treeCount == 1) {
+            sb.append("There is one tree.");
+        } else if (treeCount > 1) {
+            sb.append("A forest of ").append(treeCount).append(" trees.");
+        } else {
+            sb.append("No trees.");
+        }
+        sb.append("\n");
+    }
+
+    private static boolean dfs(int node, int parent) {
+        for (Integer next : edge[node]) {
+            if (next == parent) continue; // 부모 노드와의 연결은 무시
+
+            if (visit[next]) { // 부모가 아닌 이미 방문한 노드를 만나면 사이클
+                return true;
+            }
+
+            visit[next] = true;
+
+            if (dfs(next, node)) {
+                return true;
+            }
+        }
+
+        return false; // 사이클을 발견하지 못함
+    }
+}

--- a/src/baekjoon/트리와_쿼리_15681.java
+++ b/src/baekjoon/트리와_쿼리_15681.java
@@ -1,0 +1,69 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 2 ≤ N ≤ 105
+ * 1 ≤ R ≤ N
+ * 1 ≤ Q ≤ 105
+ *
+ * 시간 제한: 1초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N)
+ * 메모리: 78160 KB, 시간: 672 ms
+ **************************************************************************************/
+
+public class 트리와_쿼리_15681 {
+    private static List<Integer>[] edge;
+    private static int[] parent; // 노드의 부모 번호를 저장하는 배열
+    private static int[] childs; // 자신 포함 자식의 개수를 저장하는 배열
+
+    public static void main(String[] args) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int r = Integer.parseInt(st.nextToken());
+        int q = Integer.parseInt(st.nextToken());
+
+        parent = new int[n + 1];
+        childs = new int[n + 1];
+        Arrays.fill(childs, 1);
+        edge = new ArrayList[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            edge[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+
+            edge[u].add(v);
+            edge[v].add(u);
+        }
+
+        parent[r] = -1; // 루트의 parent를 -1로 설정
+        setParent(r);
+
+        for (int i = 0; i < q; i++) {
+            int u = Integer.parseInt(br.readLine());
+            sb.append(childs[u]).append("\n");
+        }
+        System.out.print(sb);
+    }
+
+    private static int setParent(int node) {
+        for (Integer next : edge[node]) {
+            if (parent[next] != 0) continue;
+
+            parent[next] = node;
+            childs[node] += setParent(next); // 자식의 수만큼 배열에 누적 저장
+        }
+
+        return childs[node];
+    }
+}

--- a/src/baekjoon/트리와_쿼리_15681.java
+++ b/src/baekjoon/트리와_쿼리_15681.java
@@ -10,7 +10,7 @@ import java.util.*;
  *
  * 시간 제한: 1초
  *------------------------------------------------------------------------------------
- * 시간복잡도: O(N)
+ * 시간복잡도: O(V + E) = O(N + N-1) = O(N)
  * 메모리: 78160 KB, 시간: 672 ms
  **************************************************************************************/
 
@@ -37,7 +37,7 @@ public class 트리와_쿼리_15681 {
             edge[i] = new ArrayList<>();
         }
 
-        for (int i = 0; i < n - 1; i++) {
+        for (int i = 0; i < n - 1; i++) { // O(E)
             st = new StringTokenizer(br.readLine());
             int u = Integer.parseInt(st.nextToken());
             int v = Integer.parseInt(st.nextToken());
@@ -56,7 +56,7 @@ public class 트리와_쿼리_15681 {
         System.out.print(sb);
     }
 
-    private static int setParent(int node) {
+    private static int setParent(int node) { // O(V + E)
         for (Integer next : edge[node]) {
             if (parent[next] != 0) continue;
 


### PR DESCRIPTION
## 4803: 트리
> 소요시간: 2시간
> 메모리: 61884 KB
> 시간: 448 ms
> 시간복잡도: O(T * (N + M))
### 간단한 풀이 
- DFS를 활용해, 이미 방문한 노드를 또 방문할 때 사이클이 발생한다고 판단
- 하지만 이때, **또 방문한 노드**가 **노드의 부모**인 경우에는 사이클이라고 판단하지 않음
- 8%에서 계속 틀려서 구글링함.. 앞선 "또 방문한 노드가 노드의 부모인 경우, 사이클 X" 조건이 빠져있어서 그랬음.. 

## 15681: 트리와 쿼리 
> 소요시간: 45분 
> 메모리: 78160 KB
> 시간: 672 ms
> 시간복잡도:  O(V + E)
### 간단한 풀이 
```java
private static int setParent(int node) { // O(V + E)
    for (Integer next : edge[node]) {
        if (parent[next] != 0) continue;

        parent[next] = node;
        childs[node] += setParent(next); // 자식의 수만큼 배열에 누적 저장
    }

    return childs[node];
}
```
- childs 배열에 현 노드의 자식 개수를 누적으로 더해줌으로서 자식 수를 체크 

## 1764: 듣보잡
> 소요시간: 10분 
> 메모리: 25928 KB
> 시간: 312 ms
> 시간복잡도:  O(N + MlogM)
### 간단한 풀이 
- HashSet을 이용해 풀이 