### PR TITLE
240806

### DIFF
--- a/src/baekjoon/벽_부수고_이동하기_2206.java
+++ b/src/baekjoon/벽_부수고_이동하기_2206.java
@@ -1,0 +1,119 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 시간 제한: 2초
+ *
+ * [회고]
+ * 반례 찾는 게 넘 어렵다.. 골드 3 이상 문제는 일반적인 조회 1번만 수행한다면 틀리는 군 ..
+ *
+ * # 반례
+ * 6 5
+ * 00000
+ * 11110
+ * 00000
+ * 01111
+ * 01111
+ * 00010
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(N*M)
+ * 메모리: 174112 KB, 시간: 796 ms
+ **************************************************************************************/
+
+public class 벽_부수고_이동하기_2206 {
+    private static int n, m;
+    private static int[][] map;
+    private static int[] dx = {0, 0, 1, -1};
+    private static int[] dy = {1, -1, 0, 0};
+
+    private static class Cell {
+        int x, y;
+        int broken;
+
+        Cell(int x, int y, int broken) {
+            this.x = x;
+            this.y = y;
+            this.broken = broken;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+            String row = br.readLine();
+
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(String.valueOf(row.charAt(j)));
+            }
+        }
+
+        System.out.print(getDistance());
+    }
+
+    private static int getDistance() {
+        int[][][] distance = new int[n][m][2];
+        // distance[i][j][0]: 0만 지나온 경우의 거리
+        // distance[i][j][1]: 벽(1)도 지나온 경우의 거리
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                distance[i][j][0] = Integer.MAX_VALUE;
+                distance[i][j][1] = Integer.MAX_VALUE;
+            }
+        }
+
+        Queue<Cell> queue = new LinkedList<>();
+        queue.offer(new Cell(0, 0, 0));
+        distance[0][0][0] = 1; // (0, 0)은 map[0][0] = 0이기에, 거리 1 설정
+
+        while (!queue.isEmpty()) {
+            Cell cur = queue.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int nx = cur.x + dx[i];
+                int ny = cur.y + dy[i];
+
+                if (oob(nx, ny)) continue;
+
+                if (map[nx][ny] == 0) { // 이동할 수 있는 칸인 경우
+                    // (nx, ny) 까지 오는 경로에 '0'만 있었다면 => 이전의 distance[0] + 1 값과 비교해, 현재 distance[0]을 세팅
+                    if (distance[cur.x][cur.y][0] != Integer.MAX_VALUE && distance[nx][ny][0] > distance[cur.x][cur.y][0] + 1) {
+                        distance[nx][ny][0] = distance[cur.x][cur.y][0] + 1;
+                        queue.offer(new Cell(nx, ny, cur.broken));
+                    }
+                    // (nx, ny) 까지 오는 경로에 '1'도 있었다면 => 이전의 distance[1] + 1 값과 비교해, 현재 distance[1]을 세팅
+                    if (distance[cur.x][cur.y][1] != Integer.MAX_VALUE && distance[nx][ny][1] > distance[cur.x][cur.y][1] + 1) {
+                        distance[nx][ny][1] = distance[cur.x][cur.y][1] + 1;
+                        queue.offer(new Cell(nx, ny, cur.broken));
+                    }
+                } else if (map[nx][ny] == 1) { // 벽인 경우
+                    // (nx, ny) 까지 오는 경로에 '0'만 있었다면 => 이전의 distance[0] + 1 값과 비교해, 현재 distance[1]을 세팅
+                    if (distance[cur.x][cur.y][0] != Integer.MAX_VALUE && distance[nx][ny][1] > distance[cur.x][cur.y][0] + 1) {
+                        distance[nx][ny][1] = distance[cur.x][cur.y][0] + 1;
+                        queue.offer(new Cell(nx, ny, cur.broken + 1));
+                    }
+
+                    // (nx, ny) 까지 오는 경로에 '1'도 있었다면 => 이전에 이미 칸을 지나왔기에 현재 칸(nx, ny)을 지날 수 없음
+                }
+            }
+        }
+
+        int arrivedDistance = Math.min(distance[n - 1][m - 1][0], distance[n - 1][m - 1][1]);
+        if (arrivedDistance == Integer.MAX_VALUE) arrivedDistance = -1;
+
+        return arrivedDistance;
+    }
+
+    private static boolean oob(int x, int y) {
+        return x < 0 || x >= n || y < 0 || y >= m;
+    }
+}

--- a/src/baekjoon/상범_빌딩_6593.java
+++ b/src/baekjoon/상범_빌딩_6593.java
@@ -1,0 +1,110 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 시간 제한: 1초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(T * (V+E)) (이떄, V = L*R*C, E = 6*V)
+ * 메모리: 17628 KB, 시간: 144 ms
+ **************************************************************************************/
+
+public class 상범_빌딩_6593 {
+    private static char[][][] building;
+    private static Index origin;
+    private static Index dest;
+    private static int l, r, c;
+    private static int[] dh = {-1, 1, 0, 0, 0, 0};
+    private static int[] dx = {0, 0, 0, 0, 1, -1};
+    private static int[] dy = {0, 0, 1, -1, 0, 0};
+
+    private static class Index {
+        int h; // 높이
+        int x, y;
+        int time;
+
+        Index(int h, int x, int y, int time) {
+            this.h = h;
+            this.x = x;
+            this.y = y;
+            this.time = time;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+
+        while (true) {
+            st = new StringTokenizer(br.readLine());
+            l = Integer.parseInt(st.nextToken());
+            r = Integer.parseInt(st.nextToken());
+            c = Integer.parseInt(st.nextToken());
+
+            if (l == 0 && r == 0 && c == 0) break;
+            building = new char[l][r][c];
+
+            for (int h = 0; h < l; h++) { // 층
+                for (int i = 0; i < r; i++) {
+                    String row = br.readLine();
+                    for (int j = 0; j < c; j++) {
+                        building[h][i][j] = row.charAt(j);
+
+                        if (building[h][i][j] == 'S') {
+                            origin = new Index(h, i, j, 0);
+                        } else if (building[h][i][j] == 'E') {
+                            dest = new Index(h, i, j, 0);
+                        }
+                    }
+                }
+                // 빈칸 예정
+                br.readLine();
+            }
+
+            int time = escapeBuilding();
+            if (time == -1) sb.append("Trapped!").append("\n");
+            else sb.append("Escaped in ").append(time).append(" minute(s).").append("\n");
+        }
+        System.out.print(sb);
+    }
+
+    private static int escapeBuilding() { // O(V + E)
+        boolean[][][] visit = new boolean[l][r][c];
+        Queue<Index> queue = new LinkedList<>();
+        queue.offer(origin);
+        visit[origin.h][origin.x][origin.y] = true;
+
+        int arrivedTime = -1;
+
+        while (!queue.isEmpty()) {
+            Index cur = queue.poll();
+
+            if (cur.h == dest.h && cur.x == dest.x && cur.y == dest.y) {
+                arrivedTime = cur.time;
+                break;
+            }
+
+            for (int i = 0; i < 6; i++) {
+                int nh = cur.h + dh[i];
+                int nx = cur.x + dx[i];
+                int ny = cur.y + dy[i];
+
+                if (oob(nh, nx, ny)) continue;
+                if (visit[nh][nx][ny]) continue;
+                if (building[nh][nx][ny] == '#') continue;
+
+                visit[nh][nx][ny] = true;
+                queue.offer(new Index(nh, nx, ny, cur.time + 1));
+            }
+        }
+
+        return arrivedTime;
+    }
+
+    private static boolean oob(int h, int x, int y) {
+        return h < 0 || h >= l || x < 0 || x >= r || y < 0 || y >= c;
+    }
+}

--- a/src/baekjoon/안전_영역_2468.java
+++ b/src/baekjoon/안전_영역_2468.java
@@ -1,0 +1,73 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**************************************************************************************
+ * 시간 제한: 1초
+ *------------------------------------------------------------------------------------
+ * 시간복잡도: O(100 * (V+E)) = O(100 * N * N)
+ * 메모리: 19112 KB, 시간: 216 ms
+ **************************************************************************************/
+
+public class 안전_영역_2468 {
+    private static int n;
+
+    private static int[] dx = {0, 0, 1, -1};
+    private static int[] dy = {1, -1, 0, 0};
+
+    private static boolean[][] visit;
+    private static int[][] area;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        area = new int[n][n];
+
+        StringTokenizer st;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                area[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int maxSafeArea = 0;
+        for (int height = 0; height <= 100; height++) { // 비가 안 오는 경우도 있기 떄문에, 0부터 시작해줘야 함
+            visit = new boolean[n][n];
+            int safeArea = 0;
+
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (!visit[i][j] && area[i][j] > height) {
+                        visit[i][j] = true;
+                        dfs(i, j, height);
+                        safeArea++;
+                    }
+                }
+            }
+            maxSafeArea = Math.max(maxSafeArea, safeArea);
+        }
+
+        System.out.println(maxSafeArea);
+    }
+
+    private static void dfs(int x, int y, int height) { // O(V+E)
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if (oob(nx, ny)) continue;
+            if (visit[nx][ny]) continue;
+            if (area[nx][ny] <= height) continue;
+
+            visit[nx][ny] = true;
+            dfs(nx, ny, height);
+        }
+    }
+
+    private static boolean oob(int x, int y) {
+        return x < 0 || x >= n || y < 0 || y >= n;
+    }
+}


### PR DESCRIPTION
## 6593: 상범 빌딩
> 소요시간: 20분
> 시간복잡도: O(T * (V+E)) (이때, V = L*R*C, E = 6*V)
> 메모리: 17628 KB
> 시간: 144 ms
### 간단한 풀이
- bfs로 풀이 

## 2206: 벽 부수고 이동하기
> 소요시간: 1시간 45분
> 시간복잡도: O(N*M)
> 메모리: 174112 KB
> 시간: 796 ms
### 간단한 풀이
- distance[x][y][0]과 distance[x][y][1] 을 사용 
  - distance[0] : 0만 지나온 경로의 최단 거리 저장
  - distance[1] : 0과 1 모두 지나온 경로의 최단 거리 저장 (1은 한 번만 지날 수 있음) 
- 현재 칸이 0이라면, distance[0]과 distance[1] 모두 고려해주기 
  - 벽을 1번 부순 경로도 0을 지날 수 있고, 0만 지나온 경로도 0을 지날 수 있기 때문
- 현재 칸이 1이라면, distance[0]만 고려해주기
  - 벽을 1번 부순 경로를 고려한다면, 이전에 부순 벽 1개와 현재 벽 1개를 부순 것이기 때문에 결과적으로 벽을 2개 부수게 된 것으로 됨 => 따라서 distance[1]은 고려 X 


## 2468: 안전 영역
> 소요시간: 20분
> 시간복잡도: O(100 * (V+E)) = O(100 * N * N)
> 메모리: 19112 KB
> 시간: 216 ms
### 간단한 풀이
- dfs로 풀이 